### PR TITLE
Convert Deployment to DaemonSet for multi-master

### DIFF
--- a/helm/k8s-audit-metrics-app/templates/daemonset.yaml
+++ b/helm/k8s-audit-metrics-app/templates/daemonset.yaml
@@ -1,18 +1,14 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    {{- include "k8s-audit-metrics.labels" . | nindent 4 }}
+      app: {{ .Values.resource.default.name . }}
 spec:
-  replicas: 1
-  revisionHistoryLimit: 3
   selector:
     matchLabels:
-      {{- include "k8s-audit-metrics.selectorLabels" . | nindent 6 }}
-  strategy:
-    type: Recreate
+      app: {{ .Values.resource.default.name }}
   template:
     metadata:
       annotations:
@@ -80,3 +76,7 @@ spec:
           limits:
             cpu: 250m
             memory: 250Mi
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/helm/k8s-audit-metrics-app/templates/daemonset.yaml
+++ b/helm/k8s-audit-metrics-app/templates/daemonset.yaml
@@ -4,11 +4,11 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-      app: {{ .Values.resource.default.name . }}
+    {{- include "k8s-audit-metrics.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Values.resource.default.name }}
+      {{- include "k8s-audit-metrics.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
In order to be able to capture audit logs from all master instances, the
deployment type must be DaemonSet with node selector to masters.