### PR TITLE
Change metric type to counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change request metric from latency histogram to simple counter.
+
 ## [0.0.2] - 2020-12-04
 
 ### Changed

--- a/collector/audit_log.go
+++ b/collector/audit_log.go
@@ -11,13 +11,13 @@ const Namespace = "k8s_api_audit"
 type AuditLogCollector struct {
 	logger micrologger.Logger
 
-	requests *prometheus.HistogramVec
+	requests *prometheus.CounterVec
 }
 
 func New(logger micrologger.Logger) *AuditLogCollector {
-	requestsOpts := prometheus.HistogramOpts{
+	requestsOpts := prometheus.CounterOpts{
 		Namespace: Namespace,
-		Name:      "requests",
+		Name:      "requests_total",
 		Help:      "apiserver requests processed from audit log",
 	}
 
@@ -26,7 +26,7 @@ func New(logger micrologger.Logger) *AuditLogCollector {
 	return &AuditLogCollector{
 		logger: logger,
 
-		requests: prometheus.NewHistogramVec(requestsOpts, labelNames),
+		requests: prometheus.NewCounterVec(requestsOpts, labelNames),
 	}
 }
 
@@ -44,5 +44,5 @@ func (c *AuditLogCollector) Process(event audit.Event) {
 		"user_agent": event.UserAgent,
 	}
 
-	c.requests.With(labels).Observe(event.StageTimestamp.Time.Sub(event.RequestReceivedTimestamp.Time).Seconds())
+	c.requests.With(labels).Inc()
 }


### PR DESCRIPTION
Kubernetes apiserver already logs request latency metrics. Here we are more
interested in request counts per client. It makes easier to see `rate()` per
operator for example.