### PR TITLE
Add required annotations for TC svc discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added missing annotations to get service picked up from tenant cluster by prometheus.
+
 ## [0.0.5] - 2020-12-07
 
 ### Changed

--- a/helm/k8s-audit-metrics-app/templates/service.yaml
+++ b/helm/k8s-audit-metrics-app/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     giantswarm.io/monitoring: "true"
   annotations:
     giantswarm.io/monitoring-path: "/metrics"
-    giantswarm.io/monigoring-port: 8000
+    giantswarm.io/monitoring-port: 8000
     giantswarm.io/monitoring: "true"
     prometheus.io/scrape: "true"
 spec:

--- a/helm/k8s-audit-metrics-app/templates/service.yaml
+++ b/helm/k8s-audit-metrics-app/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "k8s-audit-metrics.labels" . | nindent 4 }}
     giantswarm.io/monitoring: "true"
   annotations:
+    giantswarm.io/monitoring-path: "/metrics"
+    giantswarm.io/monigoring-port: 8000
+    giantswarm.io/monitoring: "true"
     prometheus.io/scrape: "true"
 spec:
   ports:


### PR DESCRIPTION
In order to trigger prometheus service discovery on tenant cluster, certain
specific annotations must be set.