### PR TITLE
Do not restart on inode change

### DIFF
--- a/tail/file.go
+++ b/tail/file.go
@@ -30,33 +30,33 @@ func File(name string, logger micrologger.Logger) (<-chan string, error) {
 func readFile(ctx context.Context, name string, output chan string, logger micrologger.Logger) error {
 	f, err := os.Open(name)
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 	defer f.Close()
 
 	// Seek to the end of the file to not repeat earlier lines.
 	_, err = f.Seek(0, 2)
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	// Capture file inode number to detect log rotation.
 	inodeBeginning, err := getInode(name)
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	reader := newLineReader(f)
 
 	err = reader.readLines(output)
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	for {
 		inode, err := getInode(name)
 		if err != nil {
-			return err
+			return microerror.Mask(err)
 		}
 
 		if inodeBeginning != inode {
@@ -67,7 +67,7 @@ func readFile(ctx context.Context, name string, output chan string, logger micro
 
 		err = reader.readLines(output)
 		if err != nil {
-			return err
+			return microerror.Mask(err)
 		}
 
 		time.Sleep(10 * time.Millisecond)

--- a/tail/file.go
+++ b/tail/file.go
@@ -14,61 +14,66 @@ func File(name string, logger micrologger.Logger) (<-chan string, error) {
 	ctx := context.Background()
 	output := make(chan string, 2)
 
+	go func() {
+		defer close(output)
+		for {
+			if err := readFile(ctx, name, output, logger); err != nil {
+				logger.Errorf(ctx, err, "read")
+				break
+			}
+		}
+	}()
+
+	return output, nil
+}
+
+func readFile(ctx context.Context, name string, output chan string, logger micrologger.Logger) error {
 	f, err := os.Open(name)
 	if err != nil {
-		logger.Errorf(ctx, err, "open")
-		return nil, microerror.Mask(err)
+		return err
 	}
+	defer f.Close()
 
 	// Seek to the end of the file to not repeat earlier lines.
 	_, err = f.Seek(0, 2)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return err
 	}
 
 	// Capture file inode number to detect log rotation.
 	inodeBeginning, err := getInode(name)
 	if err != nil {
-		logger.Errorf(ctx, err, "stat")
-		return nil, microerror.Mask(err)
+		return err
 	}
 
 	reader := newLineReader(f)
 
-	go func() {
-		defer f.Close()
-		defer close(output)
+	err = reader.readLines(output)
+	if err != nil {
+		return err
+	}
+
+	for {
+		inode, err := getInode(name)
+		if err != nil {
+			return err
+		}
+
+		if inodeBeginning != inode {
+			// File has been rotated. We need to restart.
+			logger.Debugf(ctx, "inode has changed (was %q, now %q)", inodeBeginning, inode)
+			break
+		}
 
 		err = reader.readLines(output)
 		if err != nil {
-			logger.Errorf(ctx, err, "read")
-			return
+			return err
 		}
 
-		for {
-			inode, err := getInode(name)
-			if err != nil {
-				logger.Errorf(ctx, err, "stat")
-				break
-			}
+		time.Sleep(10 * time.Millisecond)
+	}
 
-			if inodeBeginning != inode {
-				// File has been rotated. We need to restart.
-				logger.Debugf(ctx, "inode has changed (was %q, now %q)", inodeBeginning, inode)
-				break
-			}
-
-			err = reader.readLines(output)
-			if err != nil {
-				logger.Errorf(ctx, err, "read")
-				break
-			}
-
-			time.Sleep(10 * time.Millisecond)
-		}
-	}()
-
-	return output, nil
+	return nil
 }
 
 func getInode(fileName string) (uint64, error) {

--- a/tail/file.go
+++ b/tail/file.go
@@ -61,7 +61,7 @@ func readFile(ctx context.Context, name string, output chan string, logger micro
 
 		if inodeBeginning != inode {
 			// File has been rotated. We need to restart.
-			logger.Debugf(ctx, "inode has changed (was %q, now %q)", inodeBeginning, inode)
+			logger.Debugf(ctx, "inode has changed (was %d, now %d)", inodeBeginning, inode)
 			break
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19077

Current behaviour is that the process restarts every time the log file gets rotated. That results in a bit too many restarts over time and gives the impression that something is wrong where this is just the desired behaviour.