### PR TITLE
Reduce authentication_stale_token label cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce cardinality for the `authentication_stale_token` label.
+
 ## [0.5.2] - 2022-11-02
 
 ### Changed


### PR DESCRIPTION
When trying to reduce prometheus resource usage, we found that the `authentication_stale_token` label in  `k8s_api_audit_request_duration_nanoseconds` metric has a really high cardinality because the value used as a label contains a timestamp:

 `authentication_stale_token="subject: system:serviceaccount:giantswarm:falco, seconds after warning threshold: 10028"`

The threshold here is different on every scrape and this value is not used. This PR tries to extract the name of the subject using a stale token and removes the threshold as it should either be a metric value or not used at all.

I did not find any use of this metric or label anywhere but I guess @giantswarm/team-phoenix should know better than I do

Towards https://github.com/giantswarm/giantswarm/issues/25937