### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.8.0] - 2023-10-18
 
 ### Changed
@@ -93,10 +97,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds new authentication.k8s.io/stale-token audit annotation, introduced by Bound Service Account tokens enhancement, as metric label.
 
-## [0.1.0] - 2021-11-02
+## [0.1.0] - 2020-12-04
 
-- Add `k8s_api_audit_request_duration_nanoseconds` metric to expose request duration.
-- Add `authorization_decision` and `authorization_decision_reason` labels to all metrics.
+- First release.
+
+
+[Unreleased]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.6.1...v0.7.0
+[0.6.1]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.6.0...v0.6.0
+[0.6.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.6.0...v0.6.0
+[0.6.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.6.0...v0.6.0
+[0.6.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.5.3...v0.6.0
+[0.5.3]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.5.2...v0.5.3
+[0.5.2]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.4.2...v0.5.0
+[0.4.2]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.7...v0.1.0
+[0.0.7]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/giantswarm/k8s-audit-metrics/releases/tag/v0.0.1
 
 ## [0.0.7] - 2020-12-07
 
@@ -133,35 +164,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Convert `Deployment` to `DaemonSet` and schedule POD to all masters.
 - Mount `/var/log` to POD and tail `/var/log/apiserver/audit.log` for event processing.
-
-## [0.1.0] - 2020-12-04
-
-- First release.
-
-
-[Unreleased]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.8.0...HEAD
-[0.8.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.7.1...v0.8.0
-[0.7.1]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.7.0...v0.7.1
-[0.7.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.6.1...v0.7.0
-[0.6.1]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.6.0...v0.6.0
-[0.6.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.6.0...v0.6.0
-[0.6.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.6.0...v0.6.0
-[0.6.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.5.3...v0.6.0
-[0.5.3]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.5.2...v0.5.3
-[0.5.2]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.5.1...v0.5.2
-[0.5.1]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.5.0...v0.5.1
-[0.5.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.4.2...v0.5.0
-[0.4.2]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.4.1...v0.4.2
-[0.4.1]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.7...v0.1.0
-[0.0.7]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.6...v0.0.7
-[0.0.6]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.5...v0.0.6
-[0.0.5]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.4...v0.0.5
-[0.0.4]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.3...v0.0.4
-[0.0.3]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.2...v0.0.3
-[0.0.2]: https://github.com/giantswarm/k8s-audit-metrics/compare/v0.0.1...v0.0.2
-[0.0.1]: https://github.com/giantswarm/k8s-audit-metrics/releases/tag/v0.0.1

--- a/helm/k8s-audit-metrics-app/values.yaml
+++ b/helm/k8s-audit-metrics-app/values.yaml
@@ -2,7 +2,7 @@ project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: "giantswarm/k8s-audit-metrics"
   tag: "[[ .Version ]]"
 pod:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
