### PR TITLE
Set `readOnlyRootFilesystem` to true in the container security context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `readOnlyRootFilesystem` to true in the container security context.
+
 ## [0.9.0] - 2024-04-01
 
 ### Added

--- a/helm/k8s-audit-metrics-app/templates/daemonset.yaml
+++ b/helm/k8s-audit-metrics-app/templates/daemonset.yaml
@@ -50,6 +50,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+        readOnlyRootFilesystem: true
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
       containers:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31180

This PR sets readOnlyRootFilesystem to true for the container.